### PR TITLE
Doc/mkdocs create

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: docs
+on:
+  push:
+    paths: 
+      - 'docs/**'
+      - 'mkdocs.yml'
+    branches: [ "main" ]
+  pull_request:
+    paths: 
+      - 'docs/**'
+      - 'mkdocs.yml'
+    branches: [ "main" ]
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/multi_platform_build.yml
+++ b/.github/workflows/multi_platform_build.yml
@@ -9,6 +9,8 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'CODE_OF_CONDUCT.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
     branches: [ "main" ]
   pull_request:
     paths-ignore: 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,132 @@
 build/
 .vscode/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@
 
 [![Product Name Screen Shot][product-screenshot]](https://example.com)
 
-Project Description
+I_Chinese is a language study tool focused on learning languange in context.
+Designed as a tool for learning Chinese through context, I_Chinese provides
+a system where you can practice your chinese skills with real sentences.
+With controls for HSK level, starred words, and more I_Chinese gives a place
+you can continue your languge learning journey.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 *** Thanks again! Now go create something AMAZING! :D
 -->
 
-
-
 <!-- PROJECT SHIELDS -->
 <!--
 *** I'm using markdown "reference style" links for readability.
@@ -24,8 +22,6 @@
 [![MIT License][license-shield]][license-url]
 [![LinkedIn - Nicolas Janis][linkedin-shield-nj]][linkedin-url-nj]
 [![LinkedIn - Taylor Perry][linkedin-shield-tp]][linkedin-url-tp]
-
-
 
 <!-- PROJECT LOGO -->
 <br />
@@ -47,8 +43,6 @@
     <a href="https://github.com/TAP327/I_Chinese/issues">Request Feature</a>
   </p>
 </div>
-
-
 
 <!-- TABLE OF CONTENTS -->
 <details>
@@ -101,17 +95,45 @@ Project Description
 
 <!-- GETTING STARTED -->
 ## Getting Started
-!TODO
+
+The easiest way to get started is to download the latest release for your system from the releases tab [here](https://github.com/TAP327/I_Chinese/releases) on Github.
+
+If you would like to contribute or build for an unsupported platform, you can follow these build instructions.
 
 ### Prerequisites
 
+* SDL
+* CMake
+* GCC/Clang
+
+### Linux Setup
+
+```bash
+sudo apt update
+sudo apt install cmake
+sudo apt install libsdl-dev
+```
+
+### Mac Setup
+
+```bash
+brew update
+brew install cmake
+brew install sdl2
+```
+
 ### Installation
+
 ```bash
 git clone git@github.com:TAP327/I_Chinese.git
 
-!TODO: Build instructions
+mkdir build
+cmake --preset={linux-release,macos-release,windows-release}
+cmake --build build/{linux-relealse, macos-release, windows-release}
 
 ```
+
+Note: Select the release you would like (i.e linux-release, macos-release, or window-release) when building.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -122,6 +144,7 @@ git clone git@github.com:TAP327/I_Chinese.git
 
 ```
 ```
+
 _For more examples, please refer to the [Documentation](https://example.com)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -129,15 +152,20 @@ _For more examples, please refer to the [Documentation](https://example.com)_
 
 <!-- DOCS -->
 ## Read The Docs
+
 Currently, docs can only be served and viewed locally. To do so,
 follow the instructions below to set up and view the docs locally
 using mkdocs.
 
+### Docs Installation
 
-### Installation
 ```bash
+pip install mkdocs mkdocs-material
+
 git clone git@github.com:TAP327/I_Chinese.git
 
+cd I_Chinese
+mkdocs serve
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -193,10 +221,7 @@ Project Link: [https://github.com/TAP327/I_Chinese](https://github.com/TAP327/I_
 <!-- ACKNOWLEDGMENTS -->
 ## Acknowledgments
 
-
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@
       <a href="#getting-started">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
+        <li><a href="#linux-setup">Linux Setup</a></li>
+        <li><a href="#mac-setup">Mac Setup</a></li>
         <li><a href="#installation">Installation</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="#read-the-docs">Read The Docs</a>
+      <ul>
+        <li><a href="#docs-installation">Docs Installation</a></li>
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Welcome to the contributors page!
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are greatly appreciated.
+
+If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "feature". Don't forget to give the project a star! Thanks again!
+
+1. Fork the Project
+2. Create your Feature Branch (git checkout -b feature/AmazingFeature)
+3. Commit your Changes (git commit -m 'Add some AmazingFeature')
+4. Push to the Branch (git push origin feature/AmazingFeature)
+5. Open a Pull Request
+
+Some important information to keep in mind when contributing is that we use a version of semantic versioning to keep track of our versions for I_Chinese.
+Because of this, we label our branches and pull requests in the following manner.
+
+When opening issues follow this schema:
+
+[FEATURE]
+
+- Used for new features or enhancements.
+- Typically mapped to a minor version bump in semantic versioning.
+
+[BUG]
+
+- Used for bug fixes.
+- Mapped to a patch version bump.
+
+[DOC]
+
+- Used for documentation updates.
+- Often ignored in versioning but may still be included in the changelog.
+
+[CHORE]
+
+- For non-functional updates, like CI/CD configuration changes.
+- Often ignored in versioning.
+[REFACTOR]
+
+- For refactoring code without changing functionality.
+- May be excluded from version bumps.
+
+[TEST]
+
+- For test-related changes.
+- May be excluded from version bumps.
+
+[BREAKING]
+
+- Indicates a breaking change in the API.
+- Mapped to a major version bump.
+
+So, when creating an issue use something like `[FEATURE] - Amazing new feature` from there follow our issue templates.
+
+Secondly, we label our branches the same way, with the type of change first followed by a `/` and then all words seperated with `-`.
+For example, the branch for the above feature would be `feature/amazing-new-change`.
+
+Lastly, thank you for all your help and support. Happy contributing and using I_Chinese!

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,22 @@
+# Getting Started
+
+The easiest way to get started is to download the latest release for your system from the releases tab [here](https://github.com/TAP327/I_Chinese/releases) on Github.
+
+If you would like to contribute or build for an unsupported platform, you can follow these build instructions.
+
+## Build From Source
+
+```bash
+git clone git@github.com:TAP327/I_Chinese.git
+
+mkdir build
+cmake --preset={linux-release,macos-release,windows-release}
+cmake --build build/{linux-relealse, macos-release, windows-release}
+```
+
+Note: Select the release you would like (i.e linux-release, macos-release, or window-release) when building.
+
+## Usage
+
+To run the program, either launch the program from the shortcut icon if you are using a pre-built release, or the `i-chinese` executable when building from source.
+Once the program is launched you may begin using and enjoying the program.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
-# Welcome to MkDocs
+# Welcome to I_Chinese
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+A tool to help you study HSK vocabulary in context.
 
-## Commands
+## About The Project
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+I_Chinese is a language study tool focused on learning languange in context.
+Designed as a tool for learning Chinese through context, I_Chinese provides
+a system where you can practice your chinese skills with real sentences.
+With controls for HSK level, starred words, and more I_Chinese gives a place
+you can continue your languge learning journey.
 
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+Built with C, SDL, and SQLite, I_Chinese is a fast lightweight tool for
+learning. Support support of Mac, Windows, and Linux I_Chinese is a simple
+click away in your Chinese learning journey. For more information, check
+out the rest of these docs to see how to get started and/or how to contribute
+to the project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,28 @@
+site_name: I_Chinese
+theme:
+  name: material
+  repo_url: https://github.com/TAP327/I_Chinese
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - search.suggest
+
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+      primary: teal
+      accent: purple
+    - scheme: slate
+      toggle:
+        icon: material/toggle-switch
+      primary: teal
+      accent: lime
+
+plugins:
+  - search
+
+markdown_extensions:
+  - attr_list
+  - md_in_html


### PR DESCRIPTION
This pull request closes #7. 

It adds a base template for documentation using Mkdocs-material. It includes basic information such as: 

* Main page
* Getting started
* Contributing

Also, this pull request includes auto-deployment of the docs using GitHub actions and GitHub pages. Lastly, it provides updates to the README to reflect these new additions. 