### PR TITLE
add: test infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,22 @@ foreach(ASSET ${ASSETS_FILES})
 endforeach()
 
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    enable_testing()
+
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules)
+
+    find_package(Criterion REQUIRED MODULE)
+
+    file(GLOB_RECURSE TEST_SOURCES "tests/*.c")
+    add_executable(I_Chinese_Tests ${TEST_SOURCES})
+    target_include_directories(I_Chinese_Tests PRIVATE ${CMAKE_SOURCE_DIR})
+    target_include_directories(I_Chinese_Tests PRIVATE include
+        ${CRITERION_INCLUDE_DIRS}
+    )
+    target_link_libraries(I_Chinese_Tests PRIVATE
+        ${CRITERION_LIBRARIES}
+    )
+
+    add_test(NAME AllTests COMMAND I_Chinese_Tests)
+endif()

--- a/cmake/Modules/FindCriterion.cmake
+++ b/cmake/Modules/FindCriterion.cmake
@@ -1,0 +1,27 @@
+# This file is licensed under the WTFPL version 2 -- you can see the full
+# license over at http://www.wtfpl.net/txt/copying/
+#
+# - Try to find Criterion
+#
+# Once done this will define
+#  CRITERION_FOUND - System has Criterion
+#  CRITERION_INCLUDE_DIRS - The Criterion include directories
+#  CRITERION_LIBRARIES - The libraries needed to use Criterion
+
+find_package(PkgConfig)
+
+find_path(CRITERION_INCLUDE_DIR criterion/criterion.h
+          PATH_SUFFIXES criterion)
+
+find_library(CRITERION_LIBRARY NAMES criterion libcriterion)
+
+set(CRITERION_LIBRARIES ${CRITERION_LIBRARY})
+set(CRITERION_INCLUDE_DIRS ${CRITERION_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIET and REQUIRED arguments and set CRITERION_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Criterion DEFAULT_MSG
+                                  CRITERION_LIBRARY CRITERION_INCLUDE_DIR)
+
+mark_as_advanced(CRITERION_INCLUDE_DIR CRITERION_LIBRARY)

--- a/tests/db/test_db.c
+++ b/tests/db/test_db.c
@@ -1,0 +1,6 @@
+#include <criterion/criterion.h>
+#include <stdbool.h>
+
+Test(db_loader, init_engine) {
+    cr_expect(true == true);
+}


### PR DESCRIPTION
This pull request closes #5 by adding testing capabilities using the Criterion framework. This pull request adds the required code to build the testing code in debug builds with CMake and allows for testing with CTest. This pull request includes a dummy test to test the framework but does not include any real tests. 