### PR TITLE
Test/db helper tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,16 +46,38 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
     find_package(Criterion REQUIRED MODULE)
+    find_package(SDL2 REQUIRED CONFIG)
+    find_package(SQLite3 REQUIRED)
 
     file(GLOB_RECURSE TEST_SOURCES "tests/*.c")
-    add_executable(I_Chinese_Tests ${TEST_SOURCES})
+    file(GLOB_RECURSE SOURCES "src/db/*.c")
+    add_executable(I_Chinese_Tests ${TEST_SOURCES} ${SOURCES})
     target_include_directories(I_Chinese_Tests PRIVATE ${CMAKE_SOURCE_DIR})
     target_include_directories(I_Chinese_Tests PRIVATE include
         ${CRITERION_INCLUDE_DIRS}
+        ${SDL2_INCLUDE_DIRS}
+        ${SQLite3_INCLUDE_DIRS}
     )
     target_link_libraries(I_Chinese_Tests PRIVATE
         ${CRITERION_LIBRARIES}
+        SDL2::SDL2
+        SQLite::SQLite3
     )
 
+    set(ASSET_DIR "${CMAKE_SOURCE_DIR}/assets")
+
+    # Copy assets to the build directory
+    file(GLOB ASSETS_FILES "${ASSET_DIR}/*")
+
+    # Copy the assets into the output folder (where the executable is built)
+    foreach(ASSET ${ASSETS_FILES})
+        get_filename_component(ASSET_NAME ${ASSET} NAME)
+        add_custom_command(TARGET I_Chinese_Tests POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${ASSET} $<TARGET_FILE_DIR:I_Chinese_Tests>/assets/${ASSET_NAME}
+        )
+    endforeach()
+
     add_test(NAME AllTests COMMAND I_Chinese_Tests)
+    set_tests_properties(AllTests PROPERTIES LABELS backend)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         )
     endforeach()
 
-    add_test(NAME AllTests COMMAND I_Chinese_Tests)
-    set_tests_properties(AllTests PROPERTIES LABELS backend)
+    add_test(NAME db_loader_tests COMMAND I_Chinese_Tests --suite db_loader_suites)
+    set_tests_properties(db_loader_tests PROPERTIES LABELS backend)
 endif()

--- a/tests/db/test_db.c
+++ b/tests/db/test_db.c
@@ -1,6 +1,23 @@
 #include <criterion/criterion.h>
 #include <stdbool.h>
+#include "include/db/db.h"
 
-Test(db_loader, init_engine) {
-    cr_expect(true == true);
+sqlite3 *db_handle = NULL;
+
+void db_setup(void) {
+    db_handle = init_db_engine("./assets/i_chinese.db");
+}
+
+void db_teardown(void) {
+    close_db_engine(db_handle);
+}
+
+TestSuite(db_loader_suite, .init=db_setup, .fini=db_teardown);
+
+Test(db_loader_suite, init_engine) {
+    cr_expect(db_handle != NULL, "db_handle should not be null");
+}
+
+Test(db_loader_suite, validate_schema) {
+    cr_expect(validate_db(db_handle) == SQLITE_OK, "Invalid DB schema");
 }


### PR DESCRIPTION
This PR closes #6 by adding basic tests for the DB loader using Criterion. These tests include initialization and verification of the DB. More updates will need to be made to refine these tests and likely fix the test pipeline, but this gets basic unit tests functional. 